### PR TITLE
remove quoted words in guessDelimiter

### DIFF
--- a/src/Mathielen/ImportEngine/Storage/Format/Factory/CsvAutoDelimiterFormatFactory.php
+++ b/src/Mathielen/ImportEngine/Storage/Format/Factory/CsvAutoDelimiterFormatFactory.php
@@ -19,7 +19,10 @@ class CsvAutoDelimiterFormatFactory implements FormatFactoryInterface
 
     public function guessDelimiter($line)
     {
-        $specialCharString = preg_replace('/[a-z0-9éâëïüÿçêîôûéäöüß\n\r "]/iu', '', $line);
+        # Remove quoted words :
+        $line = preg_replace('/"(.*?)"/iu', '', $line);
+        $line = preg_replace('/\'(.*?)\'/iu', '', $line);
+        $specialCharString = preg_replace('/[a-z0-9éâëïüÿçêîôûéäöüß\n\r"]/iu', '', $line);
 
         $charStats = count_chars($specialCharString, 1);
 


### PR DESCRIPTION
adds the ability to use space as a separator by removing the quoted words in the csv header (hence removing the non important spaces and all other special characters).

But I'm still not sure why the space was reintroduced in the "php7 fix" commit 46dc9d59264e89f15bc7eefbfd9f72374026bc69 .